### PR TITLE
Create ExportOptions.plist

### DIFF
--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>destination</key>
+    <string>upload</string>
+</dict>
+</plist>


### PR DESCRIPTION
`ExportOptions.plist` (plist = properties list) file describes how Xcode should export an archive and archive's destination: saved locally or uploaded.